### PR TITLE
Add missing manifests to make it happy

### DIFF
--- a/manifests/netcat-svc.yaml
+++ b/manifests/netcat-svc.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: netcat
+  labels:
+    run: netcat
+spec:
+  type: NodePort
+  # Optional - make the service headless by uncommenting the next line
+  # clusterIp: None
+  ports:
+  - port: 8000
+    targetPort: 8000
+    protocol: TCP
+    name: http
+  selector:
+    run: netcat
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: netcat
+  labels:
+    name: netcat
+    app: netcat
+    run: netcat
+    version: 0.1.0
+spec:
+  selector:
+    matchLabels:
+      run: netcat
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: netcat
+        app: netcat
+    spec:
+      containers:
+      - name: netcat
+        image: crccheck/hello-world
+        ports:
+        - containerPort: 8000
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8000
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8000


### PR DESCRIPTION
Hi. This resolves #1  by adding a reasonable manifest to replace the missing one.

I also changed the port to 8000 instead of 8080 because the [docker-hello-world](https://github.com/crccheck/docker-hello-world) I used was already configured for it. I just guessed that you were using netcat as the webserver, but I could also have used the base busybox image with `busybox httpd -f -p 8000` or [nc-pod](https://github.com/sostheim/nc-pod).

