### PR TITLE
Set memory and cpus flags to max for minikube

### DIFF
--- a/local-kubernetes.yaml
+++ b/local-kubernetes.yaml
@@ -1,6 +1,6 @@
 testcases:
   minikube:
-    setup: minikube start
+    setup: minikube start --memory=max --cpus=max
     teardown: minikube delete
   k3d:
     setup: k3d cluster create


### PR DESCRIPTION
Kind and k3d don't have resource limits, while minikube sets resource limits by default, putting minikube at a benchmarking disadvantage.

I've added the ability to pass `max` to the memory and cpus flags in minikube (https://github.com/kubernetes/minikube/pull/11692) that will be released in the upcoming v1.22.0 release. Passing the `max` value will use the max number of cpu cores and max available memory less 1GB (for overhead).

- [x] Wait for minikube v1.22.0 to be released