### PR TITLE
Output cpu time instead of cpu busy percentage

### DIFF
--- a/time-to-k8s.go
+++ b/time-to-k8s.go
@@ -42,6 +42,7 @@ type ExperimentResult struct {
 	ExitCode      int
 	Error         string
 	Timestamp     time.Time
+	CPUBusyPct    float64
 	CPUTime       time.Duration
 }
 
@@ -148,7 +149,9 @@ func runIteration(name string, setupCmd string, cleanupCmd string) (e Experiment
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		e.CPUTime = time.Duration(cr.Run(ctx).Busy * float64(e.Total.Nanoseconds()))
+		bp := cr.Run(ctx).Busy
+		e.CPUBusyPct = bp * 100
+		e.CPUTime = time.Duration(bp * float64(e.Total.Nanoseconds()))
 	}()
 
 	wg.Add(1)
@@ -273,7 +276,7 @@ func main() {
 
 	c := csv.NewWriter(outputFile)
 
-	c.Write([]string{"name", "args", "platform", "iteration", "time", "version", "exitcode", "error", "command exec (seconds)", "apiserver answering (seconds)", "kubernetes svc (seconds)", "dns svc (seconds)", "app running (seconds)", "dns answering (seconds)", "cpu time (seconds)", "total duration (seconds)"})
+	c.Write([]string{"name", "args", "platform", "iteration", "time", "version", "exitcode", "error", "command exec (seconds)", "apiserver answering (seconds)", "kubernetes svc (seconds)", "dns svc (seconds)", "app running (seconds)", "dns answering (seconds)", "cpu time (seconds)", "total duration (seconds)", "cpu busy (percent)"})
 	klog.Infof("Writing output to %s", outputFile.Name())
 	c.Flush()
 
@@ -322,6 +325,7 @@ func main() {
 				ds(e.DNSAnswering),
 				ds(e.CPUTime),
 				ds(e.Total),
+				fmt.Sprintf("%.2f", e.CPUBusyPct),
 			}
 			c.Write(fields)
 			c.Flush()

--- a/time-to-k8s.go
+++ b/time-to-k8s.go
@@ -42,7 +42,7 @@ type ExperimentResult struct {
 	ExitCode      int
 	Error         string
 	Timestamp     time.Time
-	CPUBusyPct    float64
+	CPUTime       time.Duration
 }
 
 // RunResult stores the result of an cmd.Run call
@@ -148,7 +148,7 @@ func runIteration(name string, setupCmd string, cleanupCmd string) (e Experiment
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		e.CPUBusyPct = cr.Run(ctx).Busy * 100
+		e.CPUTime = time.Duration(cr.Run(ctx).Busy * float64(e.Total.Nanoseconds()))
 	}()
 
 	wg.Add(1)
@@ -273,7 +273,7 @@ func main() {
 
 	c := csv.NewWriter(outputFile)
 
-	c.Write([]string{"name", "args", "platform", "iteration", "time", "version", "exitcode", "error", "command exec (seconds)", "apiserver answering (seconds)", "kubernetes svc (seconds)", "dns svc (seconds)", "app running (seconds)", "dns answering (seconds)", "cpu busy (percent)", "total duration (seconds)"})
+	c.Write([]string{"name", "args", "platform", "iteration", "time", "version", "exitcode", "error", "command exec (seconds)", "apiserver answering (seconds)", "kubernetes svc (seconds)", "dns svc (seconds)", "app running (seconds)", "dns answering (seconds)", "cpu time (seconds)", "total duration (seconds)"})
 	klog.Infof("Writing output to %s", outputFile.Name())
 	c.Flush()
 
@@ -320,7 +320,7 @@ func main() {
 				ds(e.DNSSvc),
 				ds(e.AppRunning),
 				ds(e.DNSAnswering),
-				fmt.Sprintf("%.2f", e.CPUBusyPct),
+				ds(e.CPUTime),
 				ds(e.Total),
 			}
 			c.Write(fields)

--- a/time-to-k8s.go
+++ b/time-to-k8s.go
@@ -276,7 +276,7 @@ func main() {
 
 	c := csv.NewWriter(outputFile)
 
-	c.Write([]string{"name", "args", "platform", "iteration", "time", "version", "exitcode", "error", "command exec (seconds)", "apiserver answering (seconds)", "kubernetes svc (seconds)", "dns svc (seconds)", "app running (seconds)", "dns answering (seconds)", "cpu time (seconds)", "total duration (seconds)", "cpu busy (percent)"})
+	c.Write([]string{"name", "args", "platform", "iteration", "time", "version", "exitcode", "error", "command exec (seconds)", "apiserver answering (seconds)", "kubernetes svc (seconds)", "dns svc (seconds)", "app running (seconds)", "dns answering (seconds)", "cpu busy (percent)", "total duration (seconds)", "cpu time (seconds)"})
 	klog.Infof("Writing output to %s", outputFile.Name())
 	c.Flush()
 
@@ -323,9 +323,9 @@ func main() {
 				ds(e.DNSSvc),
 				ds(e.AppRunning),
 				ds(e.DNSAnswering),
-				ds(e.CPUTime),
-				ds(e.Total),
 				fmt.Sprintf("%.2f", e.CPUBusyPct),
+				ds(e.Total),
+				ds(e.CPUTime),
 			}
 			c.Write(fields)
 			c.Flush()

--- a/time-to-k8s.go
+++ b/time-to-k8s.go
@@ -273,7 +273,7 @@ func main() {
 
 	c := csv.NewWriter(outputFile)
 
-	c.Write([]string{"name", "args", "platform", "iteration", "time", "version", "exitcode", "error", "command exec (seconds)", "apiserver answering (seconds)", "kubernetes svc (seconds)", "dns svc (seconds)", "app running (seconds)", "dns answering (seconds)", "cpu busy (percent)", "total duration (seconds)"})
+	c.Write([]string{"name", "args", "platform", "iteration", "time", "version", "exitcode", "error", "command exec (seconds)", "apiserver answering (seconds)", "kubernetes svc (seconds)", "dns svc (seconds)", "app running (seconds)", "dns answering (seconds)", "total duration (seconds)", "cpu busy (percent)"})
 	klog.Infof("Writing output to %s", outputFile.Name())
 	c.Flush()
 
@@ -320,8 +320,8 @@ func main() {
 				ds(e.DNSSvc),
 				ds(e.AppRunning),
 				ds(e.DNSAnswering),
-				fmt.Sprintf("%.2f", e.CPUBusyPct),
 				ds(e.Total),
+				fmt.Sprintf("%.2f", e.CPUBusyPct),
 			}
 			c.Write(fields)
 			c.Flush()


### PR DESCRIPTION
CPU time can directly be computed as cpu_busy_pct * total_time. Since it's a duration, it'll fit into the current time-to-k8s charts better than cpu_busy_pct.

Sample output on my personal laptop:

|name        |args                                                        |platform|iteration|time                                                  |version                  |exitcode|error|command exec (seconds)|apiserver answering (seconds)|kubernetes svc (seconds)|dns svc (seconds)|app running (seconds)|dns answering (seconds)|cpu time (seconds)|total duration (seconds)|
|------------|------------------------------------------------------------|--------|---------|------------------------------------------------------|-------------------------|--------|-----|----------------------|-----------------------------|------------------------|-----------------|---------------------|-----------------------|------------------|------------------------|
|minikube-114|minikube start --driver=docker --kubernetes-version=v1.14.10|darwin  |1        |2021-09-04 17:17:19.178595 -0700 PDT m=+624.864202022 |minikube version: v1.22.0|       |     |70.435                |1.797                        |0.068                   |0.069            |6.658                |0.170                  |15.998            |79.198                  |
|minikube-115|minikube start --driver=docker --kubernetes-version=v1.15.12|darwin  |1        |2021-09-04 17:18:44.219993 -0700 PDT m=+709.905430551 |minikube version: v1.22.0|       |     |70.254                |1.712                        |0.069                   |0.068            |7.821                |0.174                  |16.281            |80.098                  |
|minikube-116|minikube start --driver=docker --kubernetes-version=v1.16.3 |darwin  |1        |2021-09-04 17:20:10.31169 -0700 PDT m=+795.996956542  |minikube version: v1.22.0|       |     |70.557                |1.866                        |0.106                   |0.110            |7.635                |25.366                 |18.810            |105.641                 |
|minikube-117|minikube start --driver=docker --kubernetes-version=v1.17.3 |darwin  |1        |2021-09-04 17:22:02.242473 -0700 PDT m=+907.927516542 |minikube version: v1.22.0|       |     |60.227                |1.528                        |0.064                   |0.058            |18.127               |5.169                  |18.038            |85.173                  |
|minikube-118|minikube start --driver=docker --kubernetes-version=v1.18.3 |darwin  |1        |2021-09-04 17:23:33.331963 -0700 PDT m=+999.016825324 |minikube version: v1.22.0|       |     |58.779                |1.556                        |0.065                   |0.059            |18.794               |0.168                  |17.475            |79.422                  |
|minikube-119|minikube start --driver=docker --kubernetes-version=v1.19.0 |darwin  |1        |2021-09-04 17:24:58.859762 -0700 PDT m=+1084.544454003|minikube version: v1.22.0|       |     |58.889                |1.640                        |0.065                   |0.064            |14.606               |0.199                  |17.079            |75.463                  |
