### PR TITLE
Update module to work with Go 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/tstromberg/cstat v0.0.0-20210824185534-2e5eb09ed812
+	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/klog/v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,9 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tstromberg/cstat v0.0.0-20210824185534-2e5eb09ed812 h1:ywmIyYxTCCuq4NIBNy3axFR8m9WCPdkhhVk6Fnuf6/c=
 github.com/tstromberg/cstat v0.0.0-20210824185534-2e5eb09ed812/go.mod h1:E2Gg8Bzgk9oN89qpAPchUPq2vU714oz3XVJIrNcwdAs=
-golang.org/x/sys v0.0.0-20200413165638-669c56c373c4 h1:opSr2sbRXk5X5/givKrrKj9HXxFpW2sdCiP8MJSKLQY=
 golang.org/x/sys v0.0.0-20200413165638-669c56c373c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=


### PR DESCRIPTION
When building with Go 1.18 on macOS the following occurs:
```
$ go version
go version go1.18.2 darwin/amd64

$ go build time-to-k8s.go
go: downloading github.com/tstromberg/cstat v0.0.0-20210824185534-2e5eb09ed812
go: downloading gopkg.in/yaml.v2 v2.3.0
go: downloading k8s.io/klog/v2 v2.3.0
go: downloading github.com/shirou/gopsutil v2.20.3+incompatible
go: downloading github.com/go-logr/logr v0.2.0
go: downloading golang.org/x/sys v0.0.0-20200413165638-669c56c373c4
# golang.org/x/sys/unix
Error: /Users/runner/go/pkg/mod/golang.org/x/sys@v0.0.0-20200413165638-669c56c373c4/unix/syscall_darwin.1_13.go:25:3: //go:linkname must refer to declared function or variable
Error: /Users/runner/go/pkg/mod/golang.org/x/sys@v0.0.0-20200413165638-669c56c373c4/unix/zsyscall_darwin_amd64.1_13.go:27:3: //go:linkname must refer to declared function or variable
Error: /Users/runner/go/pkg/mod/golang.org/x/sys@v0.0.0-20200413165638-669c56c373c4/unix/zsyscall_darwin_amd64.1_13.go:40:3: //go:linkname must refer to declared function or variable
Error: /Users/runner/go/pkg/mod/golang.org/x/sys@v0.0.0-20200413165638-669c56c373c4/unix/zsyscall_darwin_amd64.go:28:3: //go:linkname must refer to declared function or variable
Error: /Users/runner/go/pkg/mod/golang.org/x/sys@v0.0.0-20200413165638-669c56c373c4/unix/zsyscall_darwin_amd64.go:43:3: //go:linkname must refer to declared function or variable
Error: /Users/runner/go/pkg/mod/golang.org/x/sys@v0.0.0-20200413165638-669c56c373c4/unix/zsyscall_darwin_amd64.go:59:3: //go:linkname must refer to declared function or variable
Error: /Users/runner/go/pkg/mod/golang.org/x/sys@v0.0.0-20200413165638-669c56c373c4/unix/zsyscall_darwin_amd64.go:75:3: //go:linkname must refer to declared function or variable
Error: /Users/runner/go/pkg/mod/golang.org/x/sys@v0.0.0-20200413165638-669c56c373c4/unix/zsyscall_darwin_amd64.go:90:3: //go:linkname must refer to declared function or variable
Error: /Users/runner/go/pkg/mod/golang.org/x/sys@v0.0.0-20200413165638-669c56c373c4/unix/zsyscall_darwin_amd64.go:105:3: //go:linkname must refer to declared function or variable
Error: /Users/runner/go/pkg/mod/golang.org/x/sys@v0.0.0-20200413165638-669c56c373c4/unix/zsyscall_darwin_amd64.go:121:3: //go:linkname must refer to declared function or variable
Error: /Users/runner/go/pkg/mod/golang.org/x/sys@v0.0.0-20200413165638-669c56c373c4/unix/zsyscall_darwin_amd64.go:121:3: too many errors
Error: Process completed with exit code 2.
```

As per the [Go Language recommendation](https://stackoverflow.com/a/71508032), running `go get -u golang.org/x/sys` to update the outdated package.

The build now successfully builds on Go 1.18.